### PR TITLE
Update __init__.py

### DIFF
--- a/imageai/Detection/__init__.py
+++ b/imageai/Detection/__init__.py
@@ -78,7 +78,7 @@ class ObjectDetection:
         return unique_classes
 
     def __load_image_yolo(self, input_image : Union[str, np.ndarray, Image.Image]) -> Tuple[List[str], List[np.ndarray], torch.Tensor, torch.Tensor]:
-        allowed_exts = ["jpg", "jpeg", "png"]
+        allowed_exts = ["jpg", "jpeg", "png", "webp"]
         fnames = []
         original_dims = []
         inputs = []


### PR DESCRIPTION
Allowed extensions in opencv read list were `["jpg", "jpeg", "png"]`. `.webp` extension also also can be read by opencv. Therefore adding `webp` to the allowed_extension list.